### PR TITLE
Fix CI commit comment permissions

### DIFF
--- a/.github/workflows/main-branch-tests.yml
+++ b/.github/workflows/main-branch-tests.yml
@@ -13,6 +13,8 @@ jobs:
   test-report:
     name: Generate Test Report
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
## Summary
- Adds `contents: write` permission (scoped to the `test-report` job) so the `GITHUB_TOKEN` can post commit comments via `github.rest.repos.createCommitComment()`
- Fixes 403 "Resource not accessible by integration" error seen after merging PR #16

## Test plan
- [ ] Merge to main and verify the "Comment test results on latest commit" step succeeds without a 403 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)