### PR TITLE
Run validation workflows on main branch for badge status

### DIFF
--- a/.github/workflows/backend-validation.yml
+++ b/.github/workflows/backend-validation.yml
@@ -2,6 +2,13 @@ name: Backend Validation
 
 on:
   workflow_call:
+  push:
+    branches: [ main ]
+    paths:
+      - '**.cs'
+      - '**.csproj'
+      - '**/appsettings*.json'
+      - '.github/workflows/backend-validation.yml'
   pull_request:
     paths:
       - '**.cs'

--- a/.github/workflows/frontend-validation.yml
+++ b/.github/workflows/frontend-validation.yml
@@ -2,6 +2,11 @@ name: Frontend Validation
 
 on:
   workflow_call:
+  push:
+    branches: [ main ]
+    paths:
+      - 'PrivateSocial.Web.React/**'
+      - '.github/workflows/frontend-validation.yml'
   pull_request:
     paths:
       - 'PrivateSocial.Web.React/**'


### PR DESCRIPTION
## Summary
- Adds `push` trigger on `main` branch to both Frontend Validation and Backend Validation workflows
- Same path filters apply, so they only run when relevant files change
- Fixes "no status" README badges by ensuring these workflows have runs against the `main` branch

## Test plan
- [ ] After merge, verify both workflows trigger on the push to main
- [ ] Confirm README badges update from "no status" to passing/failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)